### PR TITLE
Remove limacharlie domain from VT queries.

### DIFF
--- a/organization/basic-coverage-with-virus-total.yaml
+++ b/organization/basic-coverage-with-virus-total.yaml
@@ -17,18 +17,22 @@ resources:
   - soteria-rules
 rules:
   vt-domains:
-    name: vt-domains
-    namespace: general
     detect:
       event: DNS_REQUEST
-      metadata_rules:
-        length of: true
-        op: is greater than
-        path: /
-        value: 4
-      op: lookup
-      path: event/DOMAIN_NAME
-      resource: lcr://api/vt
+      op: and
+      rules:
+      - path: event/DOMAIN_NAME
+        value: .limacharlie.io
+        op: ends_with
+        not: true
+      - op: lookup
+        path: event/DOMAIN_NAME
+        resource: lcr://api/vt
+        metadata_rules:
+          op: is greater than
+          length of: true
+          path: /
+          value: 4
     respond:
     - action: report
       name: vt-bad-domain


### PR DESCRIPTION
## Description of the change

Prevent the basic coverage with VT from querying for limacharlie.io domains.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #5 
