### PR TITLE
Fix 0 prefix in times.

### DIFF
--- a/solutions/github.yaml
+++ b/solutions/github.yaml
@@ -49,12 +49,12 @@ rules:
       times:
         - day_of_week_start: 1
           day_of_week_end: 7
-          time_of_day_start: 0600
+          time_of_day_start: 600 # Don't use 0600 as YAML interprets it as Octal.
           time_of_day_end: 1900
           tz: America/Los_Angeles
         - day_of_week_start: 1
           day_of_week_end: 7
-          time_of_day_start: 0600
+          time_of_day_start: 600 # Don't use 0600 as YAML interprets it as Octal.
           time_of_day_end: 1900
           tz: America/New_York
     respond:


### PR DESCRIPTION
## Description of the change

Fix the `0` prefix to numbers in YAML that is interpreted as Octal.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


