### PR TITLE
Fixing times for github again.

### DIFF
--- a/solutions/github.yaml
+++ b/solutions/github.yaml
@@ -50,11 +50,21 @@ rules:
         - day_of_week_start: 1
           day_of_week_end: 7
           time_of_day_start: 1900
+          time_of_day_end: 2359
+          tz: America/Los_Angeles
+        - day_of_week_start: 1
+          day_of_week_end: 7
+          time_of_day_start: 0
           time_of_day_end: 600 # Don't use 0600 as YAML interprets it as Octal.
           tz: America/Los_Angeles
         - day_of_week_start: 1
           day_of_week_end: 7
           time_of_day_start: 1900
+          time_of_day_end: 2359
+          tz: America/New_York
+        - day_of_week_start: 1
+          day_of_week_end: 7
+          time_of_day_start: 0
           time_of_day_end: 600 # Don't use 0600 as YAML interprets it as Octal.
           tz: America/New_York
     respond:


### PR DESCRIPTION
## Description of the change

Fixing the GitHub example's Times properly this time.
The Times require to be end > start within a day. So to cover overnight we split it up into two time ranges (7pm to midnight and midnight to 6am).

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
